### PR TITLE
Fix popup not autoclosing (#10)

### DIFF
--- a/chrome/content/alert.js
+++ b/chrome/content/alert.js
@@ -135,7 +135,18 @@ function onAlertLoad()
 
   window.moveTo(x, y);
   if(!autoClose)return;
-  if (prefBranch.getBoolPref("alerts.disableSlidingEffect")) {
+  // Bug 1352069 merged alerts.disableSlidingEffect into toolkit.cosmeticAnimations.enabled
+  var disableAnimation;
+  try {
+    disableAnimation = !prefBranch.getBoolPref("toolkit.cosmeticAnimations.enabled");
+  } catch(err) {
+    try {
+      disableAnimation = prefBranch.getBoolPref("alerts.disableSlidingEffect");
+    } catch(err) {
+      disableAnimation = false;
+    }
+  }
+  if (disableAnimation) {
     setTimeout(closeAlert, ALERT_DURATION_IMMEDIATE);
     return;
   }


### PR DESCRIPTION
[Bug 1352069](https://bugzilla.mozilla.org/show_bug.cgi?id=1352069) merged `alerts.disableSlidingEffect` into `toolkit.cosmeticAnimations.enabled`. Fixes #10.