### PR TITLE
Update nsInputStreamPump.init call

### DIFF
--- a/components/scripts/lib-socket.js
+++ b/components/scripts/lib-socket.js
@@ -23,7 +23,12 @@ dout(pi.type);*/
   var pump = Components.
     classes["@mozilla.org/network/input-stream-pump;1"].
       createInstance(Components.interfaces.nsIInputStreamPump);
-  pump.init(stream, -1, -1, 0, 0, false);
+  try {
+    // Bug 1402888 removed streamPos and streamLen parameters.
+    pump.init(stream, 0, 0, false);
+  } catch (err) {
+    pump.init(stream, -1, -1, 0, 0, false);
+  }
   pump.asyncRead(this,null);
 }
 SocketReader.prototype.write = function (data) {


### PR DESCRIPTION
[Bug 1402888](https://bugzilla.mozilla.org/show_bug.cgi?id=1402888) changed the signature of the method. Without this change, IMAP accounts don't work on Firefox 58.