### PR TITLE
Use SidebarUI.toggle instead of toggleSidebar

### DIFF
--- a/chrome/content/overlay-ff.xul
+++ b/chrome/content/overlay-ff.xul
@@ -23,7 +23,7 @@
                 oncommand="com.tobwithu.xnotifier.onOpenXN()"/>
       <menuitem id="xnotifier-sidebar" label="&xnotifier-sidebar;"
                 accesskey="&xnotifier-sidebar-key;"
-                oncommand="toggleSidebar('xnotifier-viewSidebar');"/>
+                oncommand="SidebarUI.toggle('xnotifier-viewSidebar');"/>
       <menuseparator/>
       <menuitem label="&options;"
                 accesskey="&options-key;"
@@ -106,6 +106,6 @@
                  group="sidebar"
                  sidebarurl="chrome://xnotifier/content/sidebar-ff.xul"
                  sidebartitle="&xnsidebar.label;"
-                 oncommand="toggleSidebar('xnotifier-viewSidebar');" />
+                 oncommand="SidebarUI.toggle('xnotifier-viewSidebar');" />
   </broadcasterset>
 </overlay>


### PR DESCRIPTION
`toggleSidebar` was removed in [bug 1387356](https://bugzilla.mozilla.org/show_bug.cgi?id=1387356), this broke opening the sidebar since Firefox 57.